### PR TITLE
Fix lookup of samples via remote client when they are split pieces

### DIFF
--- a/samples/models/common.py
+++ b/samples/models/common.py
@@ -976,7 +976,7 @@ class Sample(models.Model):
                 data.update(sample_details_data)
         if self.split_origin:
             ancestor_data = self.split_origin.parent.get_data(only_processes=True)
-            data.update(ancestor_data)
+            data["anchestor_data"] = ancestor_data
         data.update(("process #{}".format(process.id), process.actual_instance.get_data())
                     for process in self.processes.all())
         return data


### PR DESCRIPTION
When samples have a split_origin the sample name is overwritten by the sample name in ancestor_data. Fix: Save ancestor_data as a nested dict